### PR TITLE
feat: Allow users to specify signing/encryption keys as strings in configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,4 @@ serde = { version = "1.0.219", features = ["derive"], optional = true }
 
 [dev-dependencies]
 googletest = "0.11.0"
+serde_json = "1"

--- a/src/crypto/master.rs
+++ b/src/crypto/master.rs
@@ -274,7 +274,7 @@ mod test {
     fn debug_does_not_leak_key() {
         let key = Key::generate();
 
-        assert_eq!(format!("{:?}", key), "Key(\"***\")");
+        assert_eq!(format!("{key:?}"), "Key(\"***\")");
     }
 
     #[cfg(feature = "serde")]

--- a/src/response_cookie.rs
+++ b/src/response_cookie.rs
@@ -876,7 +876,7 @@ impl<'c> ResponseCookie<'c> {
         }
 
         if let Some(same_site) = self.same_site() {
-            write!(f, "; SameSite={}", same_site)?;
+            write!(f, "; SameSite={same_site}")?;
         }
 
         if let Some(true) = self.partitioned() {
@@ -891,11 +891,11 @@ impl<'c> ResponseCookie<'c> {
         }
 
         if let Some(path) = self.path() {
-            write!(f, "; Path={}", path)?;
+            write!(f, "; Path={path}")?;
         }
 
         if let Some(domain) = self.domain() {
-            write!(f, "; Domain={}", domain)?;
+            write!(f, "; Domain={domain}")?;
         }
 
         if let Some(max_age) = self.max_age() {


### PR DESCRIPTION
Previously, only byte arrays were supported. Now both formats are accepted.
